### PR TITLE
Added docker host support

### DIFF
--- a/docker-clean
+++ b/docker-clean
@@ -78,8 +78,20 @@ declare -a REMAINING_CONTAINERS		# Currently in use
 declare -a EMPTY_NETWORKS			# Currently in use
 #declare -a VOLUMES_TO_DELETE		# Not in use
 
+# @info:	Docker host to use (default to empty or localhost).
+declare DOCKER_HOST
 
 #FUNCTIONS
+
+# @info:  Overrides the system docker daemon so we can pass in a host
+# @args:	Global Arguments $@
+function docker(){
+	if [ -z "$DOCKER_HOST" ]; then
+		command "docker" "$@"
+	else
+		command "docker" -H "$DOCKER_HOST" "$@"
+	fi
+}
 
 # @info:    Parses and validates the CLI arguments
 # @args:	Global Arguments $@
@@ -101,11 +113,13 @@ function parseCli(){
 		esac
 	while [[ "$#" -gt 0 ]]; do
 		key="$1"
+		val="$2"
 		case $key in
 			stop ) STOP_CONTAINERS=true; CLEAN_CONTAINERS=true; CLEAN_IMAGES=true; CLEAN_VOLUMES=true; CLEAN_NETWORKS=true ;;
 			images ) DELETE_TAGGED=true; CLEAN_CONTAINERS=true; CLEAN_IMAGES=true; CLEAN_VOLUMES=true; CLEAN_NETWORKS=true ;;
 			run ) CLEAN_CONTAINERS=true; CLEAN_IMAGES=true; CLEAN_VOLUMES=true; CLEAN_NETWORKS=true ;;
 			all ) STOP_CONTAINERS=true; DELETE_TAGGED=true; CLEAN_CONTAINERS=true; CLEAN_IMAGES=true; CLEAN_VOLUMES=true; CLEAN_NETWORKS=true ;;
+			-H | --host) DOCKER_HOST=$val; shift;;
 			-s | --stop) STOP_CONTAINERS=true ;;
 			-n | --dry-run) DRY_RUN=true ;;
 			-l | --log) VERBOSE=true ;;
@@ -154,6 +168,10 @@ function usage {
 	echo "all          Stops and removes all containers, images, volumes and networks"
 	echo
 	echo "Additional Flag options:"
+	echo
+	echo "-H   or --host        Specifies the docker host to run against"
+	echo "                      Useful for docker swarm maintenance"
+	echo "                      ie: -H 127.0.0.1:4000"
 	echo
 	echo "-n   or --dry-run     Adding this additional flag will list items to be"
 	echo "                      removed without executing any stopping or removing commands"

--- a/docker-clean
+++ b/docker-clean
@@ -567,7 +567,7 @@ function restartMachine {
 			# Upstart covers SysV and OpenRC as well.
 			if [[ $init_system =~ upstart  ]]; then
 				if [[ $DRY_RUN == false ]]; then
-					sudo service docker restart
+					sudo service "docker" restart
 				else
 					echo "Restart command that would be run: sudo service docker restart"
 				fi
@@ -579,7 +579,7 @@ function restartMachine {
 				fi
 			elif [[ $init_system =~ rc ]]; then
 				if [[ $DRY_RUN == false ]]; then
-					sudo launchctl restart docker
+					sudo launchctl restart "docker"
 				else
 					echo "Restart command that would be run: sudo launchctl restart docker"
 				fi


### PR DESCRIPTION
- What I did
  Added support for being able to specify a docker host.  This is useful if you're using a remote docker host or if running docker swarm (as we are).  Running the script with this support on the swarm manager now allows swarm to clean containers on all nodes of the swarm
- How I did it

Rather than modifying each call to docker, I created an override function called docker which checks for existence of the new input parameter specified by -H.  If it's specified, it calls out to the real docker daemon and passes the -H flag to docker with the argument of the docker host specified.

Of course, I ran things through shellcheck.  The only new warning is a green around the overriding of the docker function which I followed their guidelines on quoting the command.
- Does it need a test written for it?
  I don't think so since none of the underlying docker calls changed.  The only change is to direct them to a specified docker host
- Description for the changelog

Added support for specifying a docker host
- Does it pass a ShellCheck? (excluding changes to .bats files see our CONTRIBUTING.md)
