### PR TITLE
Fix an issue where you couldn't run 'all' command inside container

### DIFF
--- a/docker-clean
+++ b/docker-clean
@@ -269,6 +269,12 @@ function stop {
 		else
 			local count=0
 			echo "Stopping running containers..."
+
+			if [ ! -d /proc/1/cgroup ] ; then
+			    self_id=$(grep 'docker/' < /proc/1/cgroup | tail -1 | sed 's/^.*\///' | cut -c 1-12)
+			    echo "Not stopping self: $self_id"
+			fi
+
 			for i in "${runningContainers[@]}"; do
 				local output
 				local status
@@ -278,16 +284,19 @@ function stop {
 				name="$(docker inspect -f '{{json .Name}}' "$i")"
 				path="$(docker inspect -f '{{json .Path}}' "$i")"
 				args="$(docker inspect -f '{{json .Args}}' "$i")"
-				docker stop "$i" &>/dev/null
-				status=$?
-				if [[ $status -eq 0 ]] ; then
-					count=$((count+1))
-					output="STOPPED: ID: $i IMAGE: $path/$args NAME: $name"
-					echo "$output" | log
-				else
-					output="COULD NOT STOP: ID: $i IMAGE: $path/$args NAME: $name"
-					echo "$output" | log
-				fi
+				if [ "$i" != "$self_id" ] ; then
+				    docker stop "$i" &>/dev/null
+
+                    status=$?
+                    if [[ $status -eq 0 ]] ; then
+                        count=$((count+1))
+                        output="STOPPED: ID: $i IMAGE: $path/$args NAME: $name"
+                        echo "$output" | log
+                    else
+                        output="COULD NOT STOP: ID: $i IMAGE: $path/$args NAME: $name"
+                        echo "$output" | log
+                    fi
+                fi
 			done
 			echo "Containers stopped: $count"
 		fi


### PR DESCRIPTION
- What I did
  Ignores itself instead of trying to stop itself if running from inside a docker container
- How I did it
  Check to see if there's a /proc/1/cgroup folder/file and if so, use that as an id to exclude
- Does it need a test written for it?
  Maybe??
- Description for the changelog
  Don't try to stop the container it may be running in
- Does it pass a ShellCheck? (excluding changes to .bats files see our CONTRIBUTING.md)
  Yes
