### PR TITLE
Support docker 1.11.1

### DIFF
--- a/Dockerfile-1.11.1
+++ b/Dockerfile-1.11.1
@@ -1,0 +1,7 @@
+FROM docker:1.11.1
+
+RUN apk add --no-cache bash
+
+COPY . /docker-clean
+
+ENTRYPOINT ["/docker-clean/docker-clean"]


### PR DESCRIPTION
Docker Cloud only supports version 1.11.1, so any engines running there cannot be cleaned by docker-clean due to `Error response from daemon: client is newer than server (client API version: 1.24, server API version: 1.23)`.

I also propose the publication of the image created by this Dockerfile-1.11.1 under a `docker-1.11.1` tag on Docker Hub.
