### PR TITLE
Windows docker run instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ For curl installs, re-running the script above will install the newest version.
 docker run --rm -v /var/run/docker.sock:/var/run/docker.sock zzrot/docker-clean [optional flags below]
 ```
 
+### Windows
+
+
+``` shell
+docker run --rm -v //var/run/docker.sock:/var/run/docker.sock zzrot/docker-clean [optional flags below]
+```
+
 *Docker Image tags can be found on [Docker Hub](https://hub.docker.com/r/zzrot/docker-clean/tags/)*
 for different docker-clean versions 2.0.4+ with various image sizes.  
 


### PR DESCRIPTION
Add instruction for running docker container on Windows.

- What I did

Add line explaining how to run the docker container on Windows

- How I did it

Tested on Windows 7 with boot2docker

